### PR TITLE
Updated to zend-expressive 1.0 API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=5.5",
         "phly/phly-mustache": "^2.0",
-        "zendframework/zend-expressive": "^0.2"
+        "zendframework/zend-expressive": "~1.0.0-dev"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.7",

--- a/doc/book/default-params.md
+++ b/doc/book/default-params.md
@@ -1,0 +1,73 @@
+# Default Params
+
+Since zend-expressive 0.5, the `TemplateRendererInterface` has provided the
+ability to specify default parameters to use when rendering, on both a global
+and a per-template level.
+
+In rendering engines such as Plates and Twig, this is generally a simple
+proposition, as they only allow passing arrays of parameters when rendering.
+However, for Mustache, where creation of view models is typical, this requires a
+little special handling.
+
+By default, we provide strategies for the following:
+
+- If an array of values is passed to `render()`, these are merged with the
+  default values, if any, with the passed values having precedence.
+- If an value object is passed to `render()`, it will attempt to inject
+  default values as object properties, assuming:
+  - the property does not already exist.
+  - a method of the same name does not already exist.
+
+Since view models often contain behavior, and may not be conducive to the above,
+we also allow you to register your own strategies, using the method
+`addParamListener()`. This method accepts a callable, which should have the
+following signature:
+
+```php
+function ($params, array $defaults)
+```
+
+If it **cannot** handle the provided `$params`, it should return void/null,
+which will allow the next listener in the stack to execute. Otherwise, it should
+attempt to merge the values, and return a value representing the merged
+structure. The first listener to return a non-void/null/scalar value will halt
+execution of the stack, and the value it returns will be used when rendering.
+
+As an example, let's consider the following view model:
+
+```php
+class User
+{
+    public $id;
+    public $fullname;
+    public $email;
+    public $uri;
+
+    public function merge(array $values)
+    {
+        if (isset($values['given_name']) && isset($values['surname'])) {
+            $this->fullname = sprintf('%s %s', $values['given_name], $values['surname']);
+        }
+        if (isset($values['url'])) {
+            $this->uri = $values['url'];
+        }
+    }
+}
+```
+
+In this case, we only want to merge specific default values, and ignore the
+rest. As such, we might register the following with the Mustache renderer
+implementation:
+
+```php
+$renderer->addParamListener(function ($vars, array $defaults) {
+    if (! $vars instanceof User) {
+        return;
+    }
+    $vars->merge($defaults);
+    return $vars;
+});
+```
+
+At this point, whenever a `User` instance is discovered, it will use the above
+listener to merge values into the view model.

--- a/doc/bookdown.json
+++ b/doc/bookdown.json
@@ -2,7 +2,8 @@
   "title": "phly-expressive-mustache: phly-mustache template adapter for Expressive",
   "content": [
       {"Introduction": "book/intro.md"},
-      {"Installation and Usage": "book/usage.md"}
+      {"Installation and Usage": "book/usage.md"},
+      {"Default Params": "book/default-params.md"}
   ],
   "target": "./html"
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,7 @@ pages:
     - index.md
     - { Introduction: intro.md }
     - { 'Installation and Usage': usage.md }
+    - { 'Default Params': default-params.md }
 site_name: phly-mustache
 site_description: 'phly-expressive-mustache: phly-mustache template adapter for Expressive'
 repo_url: 'https://github.com/phly/phly-mustache'

--- a/src/MustacheTemplate.php
+++ b/src/MustacheTemplate.php
@@ -9,14 +9,23 @@ namespace Phly\Expressive\Mustache;
 use Phly\Mustache\Mustache;
 use Phly\Mustache\Resolver\AggregateResolver;
 use Phly\Mustache\Resolver\DefaultResolver;
-use Zend\Expressive\Template\TemplateInterface;
+use Zend\Expressive\Template\DefaultParamsTrait;
+use Zend\Expressive\Template\TemplateRendererInterface;
 use Zend\Expressive\Template\TemplatePath;
+use Zend\Stdlib\ArrayUtils;
 
 /**
- * Provides a phly-mustache TemplateInterface adapter for Expressive.
+ * Provides a phly-mustache TemplateRendererInterface adapter for Expressive.
  */
-class MustacheTemplate implements TemplateInterface
+class MustacheTemplate implements TemplateRendererInterface
 {
+    use DefaultParamsTrait;
+
+    /**
+     * @var callable[]
+     */
+    private $paramListeners = [];
+
     /**
      * @var Mustache
      */
@@ -50,6 +59,46 @@ class MustacheTemplate implements TemplateInterface
         } else {
             $this->extractDefaultResolver($resolver);
         }
+
+        // Register default parameter listeners.
+        $this->paramListeners[] = function ($params, array $defaults) {
+            return $this->mergeArrayParams($params, $defaults);
+        };
+
+        $this->paramListeners[] = function ($params, array $defaults) {
+            return $this->mergeObjectParams($params, $defaults);
+        };
+    }
+
+    /**
+     * Attach a listener for merging default values.
+     *
+     * When merging default values, behavior may need to vary based on the
+     * variables passed to render(); e.g., view model objects may need to
+     * retain certain behavior in order to work correctly.
+     *
+     * To facilitate this, we provide the ability to attach parameter
+     * listeners; these receive the values passed to render(), as well as
+     * the default values, allowing a listener to decide if it can merge them
+     * for you:
+     *
+     * <code>
+     * function ($vars, array $defaults)
+     * </code>
+     *
+     * If the listener cannot handle them, it should return void (null);
+     * otherwise, it should return an array or object representing the merged
+     * values.
+     *
+     * By default, we register two listeners, one for injecting an object with
+     * public properties based on the default parameters, and another for
+     * merging array parameters.
+     *
+     * @param callable $listener
+     */
+    public function attachParamListener(callable $listener)
+    {
+        $this->paramListeners[] = $listener;
     }
 
     /**
@@ -57,6 +106,7 @@ class MustacheTemplate implements TemplateInterface
      */
     public function render($name, $vars = [])
     {
+        $vars = $this->mergeParams($name, $vars);
         return $this->renderer->render($name, $vars);
     }
 
@@ -117,5 +167,86 @@ class MustacheTemplate implements TemplateInterface
         }
 
         $this->resolver = $resolver;
+    }
+
+    /**
+     * Merge passed and default parameters.
+     *
+     * Retrieves global and template-specific default parameters, and then triggers
+     * each parameter listener with the provided $vars and the defaults, until one
+     * returns a non-null, non-scalar result that is not identical to $vars.
+     *
+     * If none returns such a result, the provided $vars are returned unmodified.
+     *
+     * @param $string $name Template name.
+     * @param array|object $vars Passed template variables.
+     * @return array|object
+     */
+    private function mergeParams($name, $vars)
+    {
+        $globalDefaults = isset($this->defaultParams[TemplateRendererInterface::TEMPLATE_ALL])
+            ? $this->defaultParams[TemplateRendererInterface::TEMPLATE_ALL]
+            : [];
+
+        $templateDefaults = isset($this->defaultParams[$name])
+            ? $this->defaultParams[$name]
+            : [];
+
+        $defaults = ArrayUtils::merge($globalDefaults, $templateDefaults);
+
+        foreach (array_reverse($this->paramListeners) as $listener) {
+            $result = $listener($vars, $defaults);
+            if (null !== $result && ! is_scalar($result)) {
+                return $result;
+            }
+        }
+
+        return $vars;
+    }
+
+    /**
+     * Merge default parameters with provided parameters.
+     *
+     * Returns $params verbatim if they are not an array.
+     *
+     * When merging, provided parameters have precedence.
+     *
+     * @param mixed $params
+     * @param array $defaults
+     * @return null|array|mixed
+     */
+    private function mergeArrayParams($params, array $defaults)
+    {
+        if (! is_array($params)) {
+            return;
+        }
+
+        return ArrayUtils::merge($defaults, $params);
+    }
+
+    /**
+     * Merge defaults with a view model object.
+     *
+     * Returns $params verbatim if they are not an object.
+     *
+     * When merging, provided parameters have precedence.
+     *
+     * @param mixed $params
+     * @param array $defaults
+     * @return object|mixed
+     */
+    private function mergeObjectParams($params, array $defaults)
+    {
+        if (! is_object($params)) {
+            return;
+        }
+
+        foreach ($defaults as $key => $value) {
+            if (! isset($params->{$key}) && ! method_exists($params, $key)) {
+                $params->{$key} = $value;
+            }
+        }
+
+        return $params;
     }
 }

--- a/test/MustacheTemplateTest.php
+++ b/test/MustacheTemplateTest.php
@@ -6,13 +6,13 @@
 
 namespace PhlyTest\Expressive\Mustache;
 
+use ArrayObject;
 use Phly\Expressive\Mustache\MustacheTemplate;
 use Phly\Mustache\Mustache;
 use Phly\Mustache\Resolver\AggregateResolver;
 use Phly\Mustache\Resolver\DefaultResolver;
 use PHPUnit_Framework_TestCase as TestCase;
-use Zend\Expressive\Template\TemplateInterface;
-use Zend\Expressive\Template\TemplatePath;
+use Zend\Expressive\Template\TemplateRendererInterface;
 
 class MustacheTemplateTest extends TestCase
 {
@@ -114,5 +114,189 @@ class MustacheTemplateTest extends TestCase
 
         $template = new MustacheTemplate($mustache->reveal());
         $this->assertEquals('RENDERED', $template->render('foo::bar', ['var' => 'value']));
+    }
+
+    public function testRendersGlobalDefaultParameters()
+    {
+        $resolver  = $this->prophesize(DefaultResolver::class);
+        $aggregate = $this->prophesize(AggregateResolver::class);
+        $aggregate->hasType(DefaultResolver::class)->willReturn(true);
+        $aggregate->fetchByType(DefaultResolver::class)->willReturn($resolver->reveal());
+
+        $mustache = $this->prophesize(Mustache::class);
+        $mustache->getResolver()->willReturn($aggregate->reveal());
+        $mustache->render('foo::bar', ['var' => 'value'])->willReturn('RENDERED');
+
+        $template = new MustacheTemplate($mustache->reveal());
+        $template->addDefaultParam(TemplateRendererInterface::TEMPLATE_ALL, 'var', 'value');
+        $this->assertEquals('RENDERED', $template->render('foo::bar'));
+    }
+
+    public function testRendersPerTemplateDefaultParameters()
+    {
+        $resolver  = $this->prophesize(DefaultResolver::class);
+        $aggregate = $this->prophesize(AggregateResolver::class);
+        $aggregate->hasType(DefaultResolver::class)->willReturn(true);
+        $aggregate->fetchByType(DefaultResolver::class)->willReturn($resolver->reveal());
+
+        $mustache = $this->prophesize(Mustache::class);
+        $mustache->getResolver()->willReturn($aggregate->reveal());
+        $mustache->render('foo::bar', ['var' => 'value'])->willReturn('RENDERED');
+
+        $template = new MustacheTemplate($mustache->reveal());
+        $template->addDefaultParam('foo::bar', 'var', 'value');
+        $this->assertEquals('RENDERED', $template->render('foo::bar'));
+    }
+
+    public function testDoesNotRenderPerTemplateDefaultParametersForDifferentTemplates()
+    {
+        $resolver  = $this->prophesize(DefaultResolver::class);
+        $aggregate = $this->prophesize(AggregateResolver::class);
+        $aggregate->hasType(DefaultResolver::class)->willReturn(true);
+        $aggregate->fetchByType(DefaultResolver::class)->willReturn($resolver->reveal());
+
+        $mustache = $this->prophesize(Mustache::class);
+        $mustache->getResolver()->willReturn($aggregate->reveal());
+        $mustache->render('bar::baz', [])->willReturn('RENDERED');
+
+        $template = new MustacheTemplate($mustache->reveal());
+        $template->addDefaultParam('foo::bar', 'var', 'value');
+
+        // Note: rendering different template than one we added a default param to!
+        $this->assertEquals('RENDERED', $template->render('bar::baz'));
+    }
+
+    public function testTemplateSpecificParametersHavePrecedenceOverGlobalParameters()
+    {
+        $resolver  = $this->prophesize(DefaultResolver::class);
+        $aggregate = $this->prophesize(AggregateResolver::class);
+        $aggregate->hasType(DefaultResolver::class)->willReturn(true);
+        $aggregate->fetchByType(DefaultResolver::class)->willReturn($resolver->reveal());
+
+        $mustache = $this->prophesize(Mustache::class);
+        $mustache->getResolver()->willReturn($aggregate->reveal());
+        $mustache->render('foo::bar', ['var' => 'VALUE'])->willReturn('RENDERED');
+
+        $template = new MustacheTemplate($mustache->reveal());
+        $template->addDefaultParam(TemplateRendererInterface::TEMPLATE_ALL, 'var', 'value');
+        $template->addDefaultParam('foo::bar', 'var', 'VALUE');
+
+        $this->assertEquals('RENDERED', $template->render('foo::bar'));
+    }
+
+    public function testParametersPassedToRenderHavePrecedenceOverTemplateSpecificParameters()
+    {
+        $resolver  = $this->prophesize(DefaultResolver::class);
+        $aggregate = $this->prophesize(AggregateResolver::class);
+        $aggregate->hasType(DefaultResolver::class)->willReturn(true);
+        $aggregate->fetchByType(DefaultResolver::class)->willReturn($resolver->reveal());
+
+        $mustache = $this->prophesize(Mustache::class);
+        $mustache->getResolver()->willReturn($aggregate->reveal());
+        $mustache->render('foo::bar', ['var' => 'VALUE'])->willReturn('RENDERED');
+
+        $template = new MustacheTemplate($mustache->reveal());
+        $template->addDefaultParam('foo::bar', 'var', 'value');
+
+        $this->assertEquals('RENDERED', $template->render('foo::bar', ['var' => 'VALUE']));
+    }
+
+    public function testParametersPassedToRenderHavePrecedenceOverGlobalParameters()
+    {
+        $resolver  = $this->prophesize(DefaultResolver::class);
+        $aggregate = $this->prophesize(AggregateResolver::class);
+        $aggregate->hasType(DefaultResolver::class)->willReturn(true);
+        $aggregate->fetchByType(DefaultResolver::class)->willReturn($resolver->reveal());
+
+        $mustache = $this->prophesize(Mustache::class);
+        $mustache->getResolver()->willReturn($aggregate->reveal());
+        $mustache->render('foo::bar', ['var' => 'VALUE'])->willReturn('RENDERED');
+
+        $template = new MustacheTemplate($mustache->reveal());
+        $template->addDefaultParam(TemplateRendererInterface::TEMPLATE_ALL, 'var', 'value');
+
+        $this->assertEquals('RENDERED', $template->render('foo::bar', ['var' => 'VALUE']));
+    }
+
+    public function testCanUseDefaultParamsWithViewModels()
+    {
+        $vars = (object) [
+            'foo' => 'bar',
+        ];
+
+        $resolver  = $this->prophesize(DefaultResolver::class);
+        $aggregate = $this->prophesize(AggregateResolver::class);
+        $aggregate->hasType(DefaultResolver::class)->willReturn(true);
+        $aggregate->fetchByType(DefaultResolver::class)->willReturn($resolver->reveal());
+
+        $mustache = $this->prophesize(Mustache::class);
+        $mustache->getResolver()->willReturn($aggregate->reveal());
+        $mustache->render('foo::bar', $vars)->willReturn('RENDERED');
+
+        $template = new MustacheTemplate($mustache->reveal());
+        $template->addDefaultParam(TemplateRendererInterface::TEMPLATE_ALL, 'var', 'value');
+
+        $this->assertEquals('RENDERED', $template->render('foo::bar', $vars));
+        $this->assertAttributeEquals('value', 'var', $vars);
+    }
+
+    public function testCanRegisterListenersForMergingDefaultParameters()
+    {
+        $vars = new ArrayObject([
+            'foo' => 'bar',
+        ]);
+
+        $resolver  = $this->prophesize(DefaultResolver::class);
+        $aggregate = $this->prophesize(AggregateResolver::class);
+        $aggregate->hasType(DefaultResolver::class)->willReturn(true);
+        $aggregate->fetchByType(DefaultResolver::class)->willReturn($resolver->reveal());
+
+        $mustache = $this->prophesize(Mustache::class);
+        $mustache->getResolver()->willReturn($aggregate->reveal());
+        $mustache->render('foo::bar', $vars)->willReturn('RENDERED');
+
+        $template = new MustacheTemplate($mustache->reveal());
+        $template->addDefaultParam(TemplateRendererInterface::TEMPLATE_ALL, 'var', 'value');
+        $template->addDefaultParam('foo::bar', 'var2', 'value2');
+        $template->attachParamListener(function ($vars, array $defaults) {
+            if (! $vars instanceof ArrayObject) {
+                return;
+            }
+            $vars['defaults'] = $defaults;
+            return $vars;
+        });
+
+        $this->assertEquals('RENDERED', $template->render('foo::bar', $vars));
+        $this->assertEquals([
+            'var'  => 'value',
+            'var2' => 'value2',
+        ], $vars['defaults']);
+    }
+
+    public function testDefaultParamListenersAreUsedIfParamListenerReturnsEmpty()
+    {
+        $vars = new ArrayObject([
+            'foo' => 'bar',
+        ], ArrayObject::ARRAY_AS_PROPS);
+
+        $resolver  = $this->prophesize(DefaultResolver::class);
+        $aggregate = $this->prophesize(AggregateResolver::class);
+        $aggregate->hasType(DefaultResolver::class)->willReturn(true);
+        $aggregate->fetchByType(DefaultResolver::class)->willReturn($resolver->reveal());
+
+        $mustache = $this->prophesize(Mustache::class);
+        $mustache->getResolver()->willReturn($aggregate->reveal());
+        $mustache->render('foo::bar', $vars)->willReturn('RENDERED');
+
+        $template = new MustacheTemplate($mustache->reveal());
+        $template->addDefaultParam(TemplateRendererInterface::TEMPLATE_ALL, 'var', 'value');
+        $template->addDefaultParam('foo::bar', 'var2', 'value2');
+        $template->attachParamListener(function ($vars, array $defaults) {
+            return;
+        });
+
+        $this->assertEquals('RENDERED', $template->render('foo::bar', $vars));
+        $this->assertAttributeEquals('value', 'var', $vars);
+        $this->assertAttributeEquals('value2', 'var2', $vars);
     }
 }


### PR DESCRIPTION
- Implement TemplateRendererInterface (instead of TemplateInterface)
- Implement `addDefaultParam()` via `DefaultParamsTrait`
- Add logic for merging default parameters:
  - Listener system via `addParamListener(function ($vars, array $defaults))`
  - New method `mergeParams()` which merges global and template-specific parameters, and then triggers all registered listeners.
  - Two default listeners, `mergeObjectParams()` and `mergeArrayParams()` cover the majority use cases.
