### PR TITLE
Added UriHelper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,8 @@ matrix:
       env:
         - EXECUTE_CS_CHECK=true
     - php: 7
-    - php: hhvm 
+    - php: hhvm
   allow_failures:
-    - php: 7
     - php: hhvm
 
 before_install:
@@ -34,6 +33,6 @@ before_script:
   - if [[ $EXECUTE_DOC_CHECK == 'true' ]]; then cp mkdocs.yml mkdocs.yml.orig ; fi
 
 script:
-  - ./vendor/bin/phpunit
-  - if [[ $EXECUTE_CS_CHECK == 'true' ]]; then ./vendor/bin/phpcs ; fi
+  - composer test
+  - if [[ $EXECUTE_CS_CHECK == 'true' ]]; then composer cs ; fi
   - if [[ $EXECUTE_DOC_CHECK == 'true' ]]; then make mkdocs ; diff mkdocs.yml mkdocs.yml.orig ; return $? ; fi

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5",
+        "php": "^5.5 || ^7.0",
         "phly/phly-mustache": "^2.0",
         "zendframework/zend-expressive-helpers": "^1.1",
         "zendframework/zend-expressive-template": "^1.0"

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     "require": {
         "php": ">=5.5",
         "phly/phly-mustache": "^2.0",
+        "zendframework/zend-expressive-helpers": "^1.1",
         "zendframework/zend-expressive-template": "^1.0"
     },
     "require-dev": {
@@ -31,5 +32,17 @@
         "psr-4": {
             "PhlyTest\\Expressive\\Mustache\\": "test/"
         }
+    },
+    "scripts": {
+        "test": [
+            "phpunit"
+        ],
+        "cs": [
+            "phpcs"
+        ],
+        "check": [
+            "@cs",
+            "@test"
+        ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=5.5",
         "phly/phly-mustache": "^2.0",
-        "zendframework/zend-expressive": "~1.0.0-dev"
+        "zendframework/zend-expressive-template": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.7",

--- a/doc/book/uri-helper.md
+++ b/doc/book/uri-helper.md
@@ -1,0 +1,74 @@
+# The URI Helper
+
+Generating URIs based on established routes is a common requirement for
+templates. This can be handled in one of two ways:
+
+- The view model can compose a utility for generating URIs, and then methods can
+  proxy to that utility to generate the URI. *This approach requires that the
+  router be injected into the view model, and proxy methods created for each URI
+  you need to generate.*
+- The view model could compose a [higher order section](http://phly-mustache.readthedocs.org/en/latest/syntax/#higher-order-sections)
+  that returns a function that will render a URI based on the text. This
+  approach is generic, but requires a syntax for describing the URI to generate.
+
+This package ships with `Phly\Expressive\Mustache\UriHelper`, which provides a
+higher order function for generating URIs based on route names. It expects a
+JSON string describing an object with minimally a "name" member, and optionally
+an "options" object with substitutions to provide when generating the URI.
+
+```mustache
+<p>
+    Make sure you <a href="{{#uri}}{"name":"documentation"}{{/uri}}">
+    read the documentation</a>.
+</p>
+
+<p>
+    Though sometimes you will <a href="{{#uri}}{"name":"resource","options":{"id":"sha1"}}{{/uri}}">
+    link to specific items.</a>
+</p>
+```
+
+While verbose, the approach gives you flexibility in generating URIs in your
+template, particularly if you'll be generating many of them.
+
+The option values can *also* include substitutions, giving you more power:
+
+```mustache
+<p>
+    I might want to <a href="{{#uri}}{"name":"user","options":{"username":"{{user}}"}}{{/uri}}">
+    link to dynamic user.</a>
+</p>
+```
+
+In the above example, `{{username}}` will be interpreted as a variable, and expanded
+as such. This approach allows you to generate URIs based on other variables in
+the view model!
+
+## Registered by default
+
+The `UriHelper` is registered as a global template [default parameter](default-params.md),
+under the name "uri". If you do not want it to be named as such, or want to
+prevent its registration with specific payloads, you can use a parameter
+listener. These generally work best when use named classes for view models, or
+if there are specific variable names or combinations present that you can
+identify.
+
+```php
+$renderer->addParamListener(function ($vars, array $defaults) {
+    if (! $vars instanceof BlogEntry) {
+        // This listener is only relevant to BlogEntry instances.
+        return;
+    }
+
+    foreach ($defaults as $key => $value) {
+        if ($key === 'uri') {
+            // Put the "uri" helper into a different property:
+            $vars->uriHelper = $value;
+            continue;
+        }
+        $vars->{$key} = $value;
+    }
+
+    return $vars;
+});
+```

--- a/doc/bookdown.json
+++ b/doc/bookdown.json
@@ -3,7 +3,8 @@
   "content": [
       {"Introduction": "book/intro.md"},
       {"Installation and Usage": "book/usage.md"},
-      {"Default Params": "book/default-params.md"}
+      {"Default Params": "book/default-params.md"},
+      {"The URI Helper": "book/uri-helper.md"}
   ],
   "target": "./html"
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ pages:
     - { Introduction: intro.md }
     - { 'Installation and Usage': usage.md }
     - { 'Default Params': default-params.md }
+    - { 'The URI Helper': uri-helper.md }
 site_name: phly-mustache
 site_description: 'phly-expressive-mustache: phly-mustache template adapter for Expressive'
 repo_url: 'https://github.com/phly/phly-mustache'

--- a/src/UriHelper.php
+++ b/src/UriHelper.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * @copyright  Copyright (c) 2015 Matthew Weier O'Phinney <matthew@weierophinney.net>
+ * @license    http://www.opensource.org/licenses/bsd-license.php New BSD License
+ */
+
+namespace Phly\Expressive\Mustache;
+
+use Phly\Mustache\Renderer\RendererInterface;
+use RuntimeException;
+use Zend\Expressive\Helper\UrlHelper;
+
+/**
+ * Helper to compose in views that require URI generation.
+ *
+ * Typically, compose this as the "uri" variable.
+ */
+class UriHelper
+{
+    private $helper;
+
+    /**
+     * Inject the UrlHelper to use for URI generation.
+     *
+     * @param UrlHelper $helper
+     */
+    public function __construct(UrlHelper $helper)
+    {
+        $this->helper = $helper;
+    }
+
+    /**
+     * Higher-order section for URI generation in templates.
+     *
+     * The function takes the text provided, and passes it to `json_decode()`;
+     * if an array containing the key `name` is returned, it passes the data
+     * along to the composed `UrlHelper` instance's `generate()` method, otherwise
+     * returning the original text verbatim.
+     *
+     * If an `options` key is also present in the data, and an array, that
+     * information is passed to the `generateUri()` method's second argument.
+     *
+     * For consumers:
+     *
+     * <code>
+     * <a href="{{#uri}}{"name": "route.name", "options": {"id": {{id}}}}{{/uri}}">
+     *     Link text
+     * </a>
+     * </code>
+     *
+     * @return callable
+     */
+    public function __invoke()
+    {
+        return function ($text, $renderer) {
+            // Decode the text .
+            $data = json_decode($text, true);
+
+            // Now, can we can use it?
+            if (! is_array($data) || ! isset($data['name'])) {
+                return $text;
+            }
+
+            $route   = $data['name'];
+            $options = $this->parseOptions($data, $renderer);
+            $uri     = $this->helper->generate($route, $options);
+
+            // Bug in URI generation; optional segments are not being stripped
+            // in FastRoute.
+            return str_replace('[/]', '', $uri);
+        };
+    }
+
+    /**
+     * Parse options
+     *
+     * It can be useful to use view data when providing options (e.g., to
+     * inject an identifier into a generated URI); this method takes the
+     * options, checking each value for templated items, and, when found,
+     * passing them through the renderer.
+     *
+     * @param array $data
+     * @param RendererInterface $renderer
+     * @return array
+     */
+    private function parseOptions(array $data, RendererInterface $renderer)
+    {
+        if (! isset($data['options']) || ! is_array($data['options'])) {
+            return [];
+        }
+
+        $options = $data['options'];
+        foreach ($options as $key => $value) {
+            if (preg_match('/\{\{[^{]+\}\}/', $value)) {
+                $options[$key] = $renderer($value);
+            }
+        }
+
+        return $options;
+    }
+}

--- a/src/UriHelper.php
+++ b/src/UriHelper.php
@@ -6,7 +6,6 @@
 
 namespace Phly\Expressive\Mustache;
 
-use Phly\Mustache\Renderer\RendererInterface;
 use RuntimeException;
 use Zend\Expressive\Helper\UrlHelper;
 
@@ -79,11 +78,14 @@ class UriHelper
      * options, checking each value for templated items, and, when found,
      * passing them through the renderer.
      *
+     * Higher order functions are passed the renderer as a callable, which
+     * accepts a string and returns a string.
+     *
      * @param array $data
-     * @param RendererInterface $renderer
+     * @param callable $renderer
      * @return array
      */
-    private function parseOptions(array $data, RendererInterface $renderer)
+    private function parseOptions(array $data, callable $renderer)
     {
         if (! isset($data['options']) || ! is_array($data['options'])) {
             return [];

--- a/src/UriHelperFactory.php
+++ b/src/UriHelperFactory.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @copyright  Copyright (c) 2015 Matthew Weier O'Phinney <matthew@weierophinney.net>
+ * @license    http://www.opensource.org/licenses/bsd-license.php New BSD License
+ */
+
+namespace Phly\Expressive\Mustache;
+
+use Interop\Container\ContainerInterface;
+use Zend\Expressive\Helper\UrlHelper;
+
+class UriHelperFactory
+{
+    public function __invoke(ContainerInterface $container)
+    {
+        return new UriHelper($container->get(UrlHelper::class));
+    }
+}

--- a/test/MustacheTemplateFactoryTest.php
+++ b/test/MustacheTemplateFactoryTest.php
@@ -9,11 +9,11 @@ namespace PhlyTest\Expressive\Mustache;
 use Interop\Container\ContainerInterface;
 use Phly\Expressive\Mustache\MustacheTemplate;
 use Phly\Expressive\Mustache\MustacheTemplateFactory;
-use Phly\Mustache\Mustache;
-use Phly\Mustache\Resolver\AggregateResolver;
-use Phly\Mustache\Resolver\DefaultResolver;
+use Phly\Expressive\Mustache\UriHelper;
 use PHPUnit_Framework_TestCase as TestCase;
-use Zend\Expressive\Template\TemplatePath;
+use Prophecy\Prophecy\ObjectProphecy;
+use ReflectionProperty;
+use Zend\Expressive\Helper\UrlHelper;
 
 class MustacheTemplateFactoryTest extends TestCase
 {
@@ -23,10 +23,36 @@ class MustacheTemplateFactoryTest extends TestCase
         $this->factory   = new MustacheTemplateFactory();
     }
 
+    public function injectContainer($name, $service)
+    {
+        $service = $service instanceof ObjectProphecy ? $service->reveal() : $service;
+        $this->container->has($name)->willReturn(true);
+        $this->container->get($name)->willReturn($service);
+    }
+
     public function testFactoryCanCreateInstanceWithoutConfiguration()
     {
-        $this->container->has('Config')->willReturn(false);
+        $this->container->has('config')->willReturn(false);
+        $this->container->has(UrlHelper::class)->willReturn(false);
         $result = $this->factory->__invoke($this->container->reveal());
         $this->assertInstanceOf(MustacheTemplate::class, $result);
+    }
+
+    public function testFactoryInjectsUriHelperAsGlobalDefaultUriParameter()
+    {
+        $this->injectContainer(UrlHelper::class, $this->prophesize(UrlHelper::class));
+
+        $this->container->has('config')->willReturn(false);
+        $mustache = $this->factory->__invoke($this->container->reveal());
+        $this->assertInstanceOf(MustacheTemplate::class, $mustache);
+
+        $r = new ReflectionProperty($mustache, 'defaultParams');
+        $r->setAccessible(true);
+        $defaultParams = $r->getValue($mustache);
+
+        $this->assertArrayHasKey('*', $defaultParams);
+        $params = $defaultParams['*'];
+        $this->assertArrayHasKey('uri', $params, var_export(array_keys($params), 1));
+        $this->assertInstanceOf(UriHelper::class, $params['uri']);
     }
 }

--- a/test/MustacheTemplateFactoryTest.php
+++ b/test/MustacheTemplateFactoryTest.php
@@ -13,7 +13,6 @@ use Phly\Mustache\Mustache;
 use Phly\Mustache\Resolver\AggregateResolver;
 use Phly\Mustache\Resolver\DefaultResolver;
 use PHPUnit_Framework_TestCase as TestCase;
-use Zend\Expressive\Template\TemplateInterface;
 use Zend\Expressive\Template\TemplatePath;
 
 class MustacheTemplateFactoryTest extends TestCase

--- a/test/UriHelperFactoryTest.php
+++ b/test/UriHelperFactoryTest.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * @copyright  Copyright (c) 2015 Matthew Weier O'Phinney <matthew@weierophinney.net>
+ * @license    http://www.opensource.org/licenses/bsd-license.php New BSD License
+ */
+
+namespace PhlyTest\Expressive\Mustache;
+
+use Interop\Container\ContainerInterface;
+use Phly\Expressive\Mustache\UriHelper;
+use Phly\Expressive\Mustache\UriHelperFactory;
+use PHPUnit_Framework_TestCase as TestCase;
+use RuntimeException;
+use Zend\Expressive\Helper\UrlHelper;
+
+class UriHelperFactoryTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->container = $this->prophesize(ContainerInterface::class);
+        $this->factory = new UriHelperFactory();
+    }
+
+    public function testReturnsAUriHelperInstanceWhenTheUrlHelperIsPresent()
+    {
+        $factory = $this->factory;
+        $baseHelper = $this->prophesize(UrlHelper::class);
+        $this->container->get(UrlHelper::class)->willReturn($baseHelper->reveal());
+        $this->assertInstanceOf(UriHelper::class, $factory($this->container->reveal()));
+    }
+
+    public function testRaisesExceptionIfTheUrlHelperIsNotPresent()
+    {
+        $factory = $this->factory;
+        $this->container->get(UrlHelper::class)->willThrow(RuntimeException::class);
+        $this->setExpectedException(RuntimeException::class);
+        $factory($this->container->reveal());
+    }
+}

--- a/test/UriHelperTest.php
+++ b/test/UriHelperTest.php
@@ -6,7 +6,6 @@
 
 namespace PhlyTest\Expressive\Mustache;
 
-use ArrayObject;
 use Phly\Expressive\Mustache\UriHelper;
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Expressive\Helper\UrlHelper;

--- a/test/UriHelperTest.php
+++ b/test/UriHelperTest.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * @copyright  Copyright (c) 2015 Matthew Weier O'Phinney <matthew@weierophinney.net>
+ * @license    http://www.opensource.org/licenses/bsd-license.php New BSD License
+ */
+
+namespace PhlyTest\Expressive\Mustache;
+
+use ArrayObject;
+use Phly\Expressive\Mustache\UriHelper;
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Expressive\Helper\UrlHelper;
+use Zend\Expressive\Router\Exception\RuntimeException;
+
+class UriHelperTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->renderer = function () {
+        };
+        $this->baseHelper = $this->prophesize(UrlHelper::class);
+    }
+
+    public function createHelper()
+    {
+        return new UriHelper($this->baseHelper->reveal());
+    }
+
+    public function nonArrayJsonPayloads()
+    {
+        return [
+            'null' => ['null'],
+            'true' => ['true'],
+            'false' => ['false'],
+            'zero' => ['0'],
+            'int' => ['1'],
+            'zero-float' => ['0.0'],
+            'float' => ['1.1'],
+            'string' => ['"name"'],
+        ];
+    }
+
+    /**
+     * @dataProvider nonArrayJsonPayloads
+     */
+    public function testNonArrayJsonDataReturnsDataVerbatim($data)
+    {
+        $helper = $this->createHelper();
+        $function = $helper();
+        $this->assertSame($data, $function($data, $this->renderer));
+    }
+
+    public function jsonArrayPayloadsWithoutNames()
+    {
+        return [
+            'indexed-array' => ['["foo", "bar"]'],
+            'object' => ['{"foo": "bar"}'],
+        ];
+    }
+
+    /**
+     * @dataProvider jsonArrayPayloadsWithoutNames
+     */
+    public function testArrayDataMissingNameElementReturnsDataVerbatim($data)
+    {
+        $helper = $this->createHelper();
+        $function = $helper();
+        $this->assertSame($data, $function($data, $this->renderer));
+    }
+
+    public function testReturnsUrlForMatchingRouteWithoutOptions()
+    {
+        $this->baseHelper->generate('resource', [])->willReturn('/resource');
+        $helper = $this->createHelper();
+        $function = $helper();
+        $url = $function('{"name":"resource"}', $this->renderer);
+        $this->assertEquals('/resource', $url);
+    }
+
+    public function testReturnsUrlForMatchingRouteWithOptionsThatContainNoExpansions()
+    {
+        $this->baseHelper->generate('resource', ['id' => 'sha1'])->willReturn('/resource/sha1');
+        $helper = $this->createHelper();
+        $function = $helper();
+        $url = $function('{"name":"resource","options":{"id":"sha1"}}', $this->renderer);
+        $this->assertEquals('/resource/sha1', $url);
+    }
+
+    public function testReturnsUrlForMatchingRouteWithOptionsThatContainExpansions()
+    {
+        $this->baseHelper->generate('user', ['user' => 'mwop'])->willReturn('/user/mwop');
+        $renderer = function ($value) {
+            $this->assertEquals('{{user}}', $value);
+            return 'mwop';
+        };
+
+        $helper = $this->createHelper();
+        $function = $helper();
+        $url = $function('{"name":"user","options":{"user":"{{user}}"}}', $renderer);
+        $this->assertEquals('/user/mwop', $url);
+    }
+
+    public function testRaisesExceptionIfRouteDoesNotExist()
+    {
+        $this->baseHelper->generate('resource', [])->willThrow(RuntimeException::class);
+        $helper = $this->createHelper();
+        $function = $helper();
+        $this->setExpectedException(RuntimeException::class);
+        $url = $function('{"name":"resource"}', $this->renderer);
+    }
+}


### PR DESCRIPTION
This patch:
- Updates to stable versions of zend-expressive-template
- Adds a dependency on zend-expressive-helpers
- Introduces the `UriHelper`, for generating URIs, which proxies to `Zend\Expressive\Helper\UrlHelper`.
- Updates the `MustacheTemplateFactory` to map a global default template parameter `uri` to a `UriHelper` instance.
