### PR TITLE
Require zend-expressive-helpers v1.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": "^5.5 || ^7.0",
         "phly/phly-mustache": "^2.0",
-        "zendframework/zend-expressive-helpers": "^1.1",
+        "zendframework/zend-expressive-helpers": "^1.2",
         "zendframework/zend-expressive-template": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
In order to prevent the circular dependency issues.
